### PR TITLE
Remove TSRI links from Chromebook quick link page

### DIFF
--- a/pages/Quick Links for Chromebook.md
+++ b/pages/Quick Links for Chromebook.md
@@ -12,65 +12,6 @@ resources safely and responsibly. All pupils must follow these guidelines
 to keep a positive and respectful learning environment.
 <br><a href="/files/Acceptable_Use_Policy_Agreement_2026.pdf" rel="noopener nofollow" target="_blank">Click to read the Acceptable Use Policy</a>
 </p>
-<hr>
-<h4><strong>TSRI Survey for Primary 4</strong></h4>
-<p>Click on the respective picture to access the survey for <a href="https://forms.moe.edu.sg/forms/Jqyr9a" rel="noopener nofollow" target="_blank"><u>Form Teacher 1</u></a> and
-<a href="https://forms.moe.edu.sg/forms/J49OWy" rel="noopener nofollow" target="_blank"><u>Form Teacher 2</u>
-</a>.</p>
-<table style="minWidth: 100px">
-<colgroup>
-<col>
-<col>
-<col>
-<col>
-</colgroup>
-<tbody>
-<tr>
-<th rowspan="1" colspan="2">
-<h4><a href="https://forms.moe.edu.sg/forms/Jqyr9a" rel="noopener nofollow" target="_blank">Form Teacher 1</a></h4>
-</th>
-<th rowspan="1" colspan="2">
-<h4><a href="https://forms.moe.edu.sg/forms/J49OWy" rel="noopener nofollow" target="_blank">Form Teacher 2</a></h4>
-</th>
-</tr>
-<tr>
-<td rowspan="1" colspan="1">
-<p>Mr Uresh</p>
-</td>
-<td rowspan="1" colspan="1">
-<p>Ms Chua Pei Tee Patty</p>
-</td>
-<td rowspan="1" colspan="1">
-<p>Mrs Soh - Ho Hwee Leng</p>
-</td>
-<td rowspan="1" colspan="1">
-<p>Mdm Suriani</p>
-</td>
-</tr>
-<tr>
-<td rowspan="1" colspan="1">
-<p>Ms Shabrina</p>
-</td>
-<td rowspan="1" colspan="1">
-<p>Ms Veevarshinie</p>
-</td>
-<td rowspan="1" colspan="1">
-<p>Mdm Chen Jing Ting</p>
-</td>
-<td rowspan="1" colspan="1">
-<p>Mr Chng Chyi Woei</p>
-</td>
-</tr>
-<tr>
-<td rowspan="1" colspan="2">
-<p></p><a class="isomer-image-wrapper" href="https://forms.moe.edu.sg/forms/Jqyr9a"><img style="width: 100%" height="auto" width="100%" alt="" src="/images/TSRI_Form_Teacher_1.jpg"></a>
-</td>
-<td rowspan="1" colspan="2">
-<p></p><a class="isomer-image-wrapper" href="https://forms.moe.edu.sg/forms/J49OWy"><img style="width: 100%" height="auto" width="100%" alt="" src="/images/TSRI_Form_Teacher_2.jpg"></a>
-</td>
-</tr>
-</tbody>
-</table>
 <p></p>
 <hr>
 <h4><strong>Quick Links</strong></h4>


### PR DESCRIPTION
Remove TSRI links from Chromebook quick link page